### PR TITLE
Fix first line detection in count_main_text_words_detex if manuscript starts with a section

### DIFF
--- a/aps-length
+++ b/aps-length
@@ -251,7 +251,7 @@ def count_main_text_words_detex(detex_lines, tex_lines):
 
     detex_first_line_no = 0
     for line in detex_lines:
-        if line.strip() == first_line.strip():
+        if line.strip() in first_line.strip():
             break
         detex_first_line_no += 1
 


### PR DESCRIPTION
First of all, thank you very much for this script. It helped me a lot.
I just stumbled over a small bug when using it. If the manuscript starts with a \section (as can be common in certain fields) the first line detection in count_main_text_words_detex breaks giving an output of 0 words for the main text.
The proposed change compares the line by checking if the text as generated by detex can be found in the tex file.
There could still be cases where this method breaks, but at least in my cases, it worked.