### PR TITLE
Fix compatibity with identify from ImageMagick 7.1.1-5

### DIFF
--- a/aps-length
+++ b/aps-length
@@ -446,12 +446,13 @@ def count_figures_words(detex_lines, tex_lines, opts):
         filename = filename+ext
 
         if opts.figs == 'identify':
-            identify = subprocess.Popen(['identify', filename],
+            identify = subprocess.Popen(['identify', '-verbose', filename],
                                         stdout=subprocess.PIPE)
             out, err = identify.communicate()
             out = out.decode()
             fields = out.split()
-            width, height = fields[2].split('x')
+            dummy_index = fields.index('size:')
+            width, height = fields[dummy_index+1].split('x')
             width = float(width)
             height = float(height)
         elif opts.figs == 'gs':


### PR DESCRIPTION
With the current implementation, figures' size is considered to be the resolution that the `identify` command returns but this an imprecise value. Using the `-verbose` option one can access a more precise value (given by the `Print size:` line) of the image size estimated by ImageMagick.