### PR TITLE
fix maketitle typo; use PyMuPDF to calc aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Usage: aps-length [options] tex-files
 Count number of equivalent words in an APS manuscript formatted in
 LaTeX, following guidelines described at http://journals.aps.org/authors/length-guide
 
+Requires PyMuPDF to be installed (`python3 -m pip install PyMuPDF`) for pdf figures.
+Note that PyMuPDF is more accurate than gs and identify for pdf figures.
+
 Requires _detex_ (http://www.ctan.org/pkg/detex) and either
 _ghostscript_ (http://www.ghostscript.com/) or ImageMagick _identify_
 (http://www.imagemagick.org) to be available on your path.

--- a/aps-length
+++ b/aps-length
@@ -27,6 +27,7 @@ import os
 import sys
 import subprocess
 import re
+import fitz
 
 word_limit = {'PRL':    3750,
               'PRA-RC': 4500,
@@ -244,7 +245,7 @@ def count_main_text_words_detex(detex_lines, tex_lines):
     detex_lines = [line for line in detex_lines if len(line.strip()) > 0]
     detex_lines = [line for line in detex_lines if '<Picture' not in line]
 
-    title_line_no, = [i for i, line in enumerate(tex_lines) if '\maketitle' in line]
+    title_line_no, = [i for i, line in enumerate(tex_lines) if '\\maketitle' in line]
     first_line_no = title_line_no + 1
     while not is_first_line(tex_lines[first_line_no]):
         first_line_no += 1
@@ -446,7 +447,12 @@ def count_figures_words(detex_lines, tex_lines, opts):
             raise IOError('missing picture file %s' % filename)
         filename = filename+ext
 
-        if opts.figs == 'identify':
+        if filename[-4:] == '.pdf':
+            pdf_file = fitz.open(filename)
+            first_page = pdf_file[0]
+            width = first_page.rect.width
+            height = first_page.rect.height
+        elif opts.figs == 'identify':
             identify = subprocess.Popen(['identify', '-verbose', filename],
                                         stdout=subprocess.PIPE)
             out, err = identify.communicate()


### PR DESCRIPTION
Somehow, gs and identify failed to correctly calculate my pdf figure.
I find that PyMuPDF yields the correct aspect ratio.
Thus I propose to use PyMuPDF to determine the figure size instead for pdf figures.