### PR TITLE
Added verbose mode and improved regex

### DIFF
--- a/aps-length
+++ b/aps-length
@@ -324,11 +324,19 @@ def count_main_text_words_wordcount(tex_lines, opts):
     wordcount_tex_file.write(wordcount_tex_contents)
     wordcount_tex_file.close()
 
-    os.system('%s tmp_tex_file > /dev/null 2>&1' % opts.latex)
-    os.system('bibtex tmp_tex_file > /dev/null 2>&1')
-    os.system('%s tmp_tex_file > /dev/null 2>&1' % opts.latex)
-    os.system('%s tmp_tex_file > /dev/null 2>&1' % opts.latex)
-    os.system(r'echo tmp_tex_file.tex | %s wordcount.tex > /dev/null 2>&1' % opts.latex)
+    def run_cmd(cmd):
+        if opts.verbose:
+            print(f"Running: {cmd}")
+            os.system(cmd)
+        else:
+            os.system(f"{cmd} > /dev/null 2>&1")
+    
+    run_cmd(f"{opts.latex} tmp_tex_file")
+    run_cmd("bibtex tmp_tex_file")
+    run_cmd(f"{opts.latex} tmp_tex_file")
+    run_cmd(f"{opts.latex} tmp_tex_file")
+    run_cmd(r"echo tmp_tex_file.tex | {} wordcount.tex".format(opts.latex))
+    
     wordcount_log = open('wordcount.log', encoding="latin-1").readlines()
 
     rm_files = glob.glob('wordcount*') + glob.glob('tmp_tex_file*')
@@ -574,7 +582,8 @@ parser.add_option('-j', '--journal', metavar='PRL', default='PRL',
                   help='Journal abbreviation (e.g. PRL, PRB-RC)')
 parser.add_option('-l', '--latex', default='pdflatex',
                   help='Latex executable. Default is "pdflatex".')
-
+parser.add_option('--verbose', action='store_true', dest='verbose', default=False,
+                  help='Enable verbose latex output')
 
 opts, args = parser.parse_args()
 

--- a/aps-length
+++ b/aps-length
@@ -428,8 +428,8 @@ def count_figures_words(detex_lines, tex_lines, opts):
 
     for fig_i, fig_line in enumerate(fig_lines):
         # filename = fig_line.strip()[1:-1].split()[1]
-        m = re.findall(r"{\S*\.pdf}|.eps}|.png}$", fig_line)
-        filename = m[0][1:-1]
+        m = re.findall(r'\\includegraphics\[.*?\]{(.*?\.(?:pdf|eps|png))}', fig_line)
+        filename = m[0]
 
         this_fig_lines = [ (i, line) for i, line in enumerate(tex_lines) if filename in line and
                            ('input' in line or 'includegraphics' in line)]


### PR DESCRIPTION
## Verbose mode

I've added the option `--verbose` for the latex compilation. This was helpful for me, as initially (due to a missing package) my latex compilation was hanging and I had no idea why. 

## Improved regex

I've changed the figure path finding regex to `m = re.findall(r'\\includegraphics\[.*?\]{(.*?\.(?:pdf|eps|png))}', fig_line)`, which captures everything inside the curly brackets ending with pdf, eps or png. This was essential for me - as it was, the regex was turning `\\includegraphics[width=\\linewidth]{figure_set_3/figure_1_draft_14.png}\n` into `png`, whilst this new version successfully captures `figure_set_3/figure_1_draft_14.png`.