### PR TITLE
Update regex to match optional graphics options

### DIFF
--- a/aps-length
+++ b/aps-length
@@ -428,7 +428,7 @@ def count_figures_words(detex_lines, tex_lines, opts):
 
     for fig_i, fig_line in enumerate(fig_lines):
         # filename = fig_line.strip()[1:-1].split()[1]
-        m = re.findall(r'\\includegraphics\[.*?\]{(.*?\.(?:pdf|eps|png))}', fig_line)
+        m = re.findall(r'\\includegraphics(?:\[.*?\])?\{(.*?\.(?:pdf|eps|png))\}', fig_line)
         filename = m[0]
 
         this_fig_lines = [ (i, line) for i, line in enumerate(tex_lines) if filename in line and


### PR DESCRIPTION
Update regex in `count_figures_words` to also detect patterns like \includegraphics{} instead of just \includegraphics[]{}